### PR TITLE
Added sort order to apis and fixed bugs

### DIFF
--- a/app/src/main/kotlin/io/alienhead/gray/matter/app/App.kt
+++ b/app/src/main/kotlin/io/alienhead/gray/matter/app/App.kt
@@ -130,13 +130,14 @@ fun Application.module() {
             get {
                 val page = call.parameters["page"]?.toIntOrNull()
                 val size = call.parameters["size"]?.toIntOrNull()
+                val sort = call.parameters["sort"]
 
                 if (page == null || page < 0 || (size != null && size < 1)) {
                     call.response.status(HttpStatusCode.BadRequest)
                     return@get
                 }
 
-                val subchain = blockchain.chain(page, size)
+                val subchain = blockchain.chain(page, size, sort)
 
                 call.respond(HttpStatusCode.OK, subchain)
             }

--- a/blockchain/src/test/kotlin/io/alienhead/gray/matter/blockchain/BlockchainTest.kt
+++ b/blockchain/src/test/kotlin/io/alienhead/gray/matter/blockchain/BlockchainTest.kt
@@ -1,11 +1,17 @@
 package io.alienhead.gray.matter.blockchain
 
+import io.alienhead.gray.matter.storage.Storage
+import io.alienhead.gray.matter.storage.StoreBlock
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.exactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import java.time.Instant
 import java.time.LocalDate
 
@@ -13,45 +19,55 @@ class BlockchainTest : DescribeSpec({
     describe("Blockchain") {
         describe("chain") {
             it("should return a list of 10 blocks") {
-                val blockchain = Blockchain(mutableListOf(
-                    Block.genesis(),
-                    randomBlock("", 1u),
-                    randomBlock("", 2u),
-                    randomBlock("", 3u),
-                    randomBlock("", 4u),
-                    randomBlock("", 5u),
-                    randomBlock("", 6u),
-                    randomBlock("", 7u),
-                    randomBlock("", 8u),
-                    randomBlock("", 9u),
-                ))
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage)
 
-                blockchain.chain(0, null) shouldHaveSize 10
+                every { storage.blocks(any(), any(), any()) } returns listOf(
+                    Block.genesis().toStore(),
+                    randomBlock("", 1u).toStore(),
+                    randomBlock("", 2u).toStore(),
+                    randomBlock("", 3u).toStore(),
+                    randomBlock("", 4u).toStore(),
+                    randomBlock("", 5u).toStore(),
+                    randomBlock("", 6u).toStore(),
+                    randomBlock("", 7u).toStore(),
+                    randomBlock("", 8u).toStore(),
+                    randomBlock("", 9u).toStore(),
+                )
+
+                blockchain.chain(0, null, null) shouldHaveSize 10
             }
 
             it("should return a list of 5 blocks when size of 5 is selected") {
-                val blockchain = Blockchain(mutableListOf(
-                    Block.genesis(),
-                    randomBlock("", 1u),
-                    randomBlock("", 2u),
-                    randomBlock("", 3u),
-                    randomBlock("", 4u),
-                    randomBlock("", 5u),
-                    randomBlock("", 6u),
-                    randomBlock("", 7u),
-                    randomBlock("", 8u),
-                    randomBlock("", 9u),
-                ))
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage)
 
-                blockchain.chain(0, 5) shouldHaveSize 5
-                blockchain.chain(1, 5) shouldHaveSize 5
+                every { storage.blocks(0, any(), any()) } returns listOf(
+                    Block.genesis().toStore(),
+                    randomBlock("", 1u).toStore(),
+                    randomBlock("", 2u).toStore(),
+                    randomBlock("", 3u).toStore(),
+                    randomBlock("", 4u).toStore(),
+                )
+
+                every { storage.blocks(1, any(), any()) } returns listOf(
+                    randomBlock("", 5u).toStore(),
+                    randomBlock("", 6u).toStore(),
+                    randomBlock("", 7u).toStore(),
+                    randomBlock("", 8u).toStore(),
+                    randomBlock("", 9u).toStore(),
+                )
+
+                blockchain.chain(0, 5, null) shouldHaveSize 5
+                blockchain.chain(1, 5, null) shouldHaveSize 5
             }
         }
 
         describe("processArticle") {
 
             it("should accept valid article") {
-                val blockchain = Blockchain(mutableListOf(Block.genesis()))
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage)
 
                 val goodArticle = randomArticle()
 
@@ -62,7 +78,11 @@ class BlockchainTest : DescribeSpec({
             describe("maximum amount of articles") {
                 it("should mint new block") {
                     val genesisBlock = Block.genesis()
-                    val blockchain = Blockchain(mutableListOf(genesisBlock))
+                    val storage = mockk<Storage>()
+                    val blockchain = Blockchain(storage)
+
+                    every { storage.latestBlock() } returns genesisBlock.toStore()
+                    every { storage.storeBlock(any()) } returns Unit
 
                     // First add the maximum amount of articles
                     repeat(9) {
@@ -82,35 +102,57 @@ class BlockchainTest : DescribeSpec({
         describe("processBlock") {
             it("should accept block with valid height and matching previousHash") {
                 val genesisBlock = Block.genesis()
-                val blockchain = Blockchain(mutableListOf(genesisBlock))
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage)
                 val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1)
+
+                every { storage.latestBlock() } returns genesisBlock.toStore()
+                every { storage.chainSize() } returns 1
+                every { storage.storeBlock(any()) } returns Unit
 
                 blockchain.processBlock(goodBlock) shouldBe true
             }
 
             it("should reject block with invalid height") {
-                val blockchain = Blockchain(mutableListOf(Block.genesis()))
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage)
                 val badBlock = randomBlock("", 0u)
 
+                every { storage.latestBlock() } returns randomBlock("", 0u).toStore()
+                every { storage.chainSize() } returns 1
                 blockchain.processBlock(badBlock) shouldBe false
             }
 
             it("should reject block without matching previousHash") {
-                val blockchain = Blockchain(mutableListOf(Block.genesis()))
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage)
                 val badBlock = randomBlock("", 1u)
+
+                every { storage.latestBlock() } returns randomBlock("", 0u).toStore()
+                every { storage.chainSize() } returns 0
 
                 blockchain.processBlock(badBlock) shouldBe false
             }
 
             it("should reject block with timestamp in the past") {
                 val genesisBlock = Block.genesis()
-                val blockchain = Blockchain(mutableListOf(genesisBlock))
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage)
                 val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1)
+
+                every { storage.latestBlock() } returns genesisBlock.toStore()
+                every { storage.chainSize() } returns 1
+                every { storage.storeBlock(any()) } returns Unit
 
                 blockchain.processBlock(goodBlock) shouldBe true
 
+                every { storage.latestBlock() } returns goodBlock.toStore()
+                every { storage.chainSize() } returns 2
+
                 val badBlock = randomBlock(goodBlock.hash, goodBlock.height + 1u, goodBlock.timestamp - 1)
                 blockchain.processBlock(badBlock) shouldBe false
+
+                verify(exactly = 1) { storage.storeBlock(any()) }
             }
         }
     }

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -1,17 +1,15 @@
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
-    id("io.ktor.plugin")
 }
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
 
-    implementation("io.ktor:ktor-serialization-kotlinx-json")
-
-    implementation("io.ktor:ktor-client-core")
-    implementation("io.ktor:ktor-client-cio")
-    implementation("io.ktor:ktor-client-content-negotiation")
+    implementation("io.ktor:ktor-client-core:3.1.0")
+    implementation("io.ktor:ktor-client-cio:3.1.0")
+    implementation("io.ktor:ktor-client-content-negotiation:3.1.0")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.1.0")
 
     implementation("ch.qos.logback:logback-classic:1.5.16")
 

--- a/sql/src/main/kotlin/io/alienhead/gray/matter/sql/Db.kt
+++ b/sql/src/main/kotlin/io/alienhead/gray/matter/sql/Db.kt
@@ -61,9 +61,11 @@ class Db(private val database: Database): Storage {
         Blocks.selectAll().count()
     }
 
-    override fun blocks(page: Int, size: Int): List<StoreBlock> = transaction(database) {
+    override fun blocks(page: Int, size: Int, sort: String?): List<StoreBlock> = transaction(database) {
+        val sortOrder = if (sort == null) SortOrder.ASC else SortOrder.valueOf(sort)
+
         Blocks.selectAll()
-            .orderBy(Blocks.height to SortOrder.ASC)
+            .orderBy(Blocks.height to sortOrder)
             .limit(size)
             .offset((page * size).toLong())
             .map {

--- a/sql/src/main/resources/db/migration/V20250222081742__init.sql
+++ b/sql/src/main/resources/db/migration/V20250222081742__init.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS block (
     id BIGSERIAL PRIMARY KEY,
     hash VARCHAR(64) NOT NULL,
     previous_hash VARCHAR(64) NOT NULL,
-    data VARCHAR(3000) NOT NULL,
+    data VARCHAR(20000) NOT NULL,
     timestamp BIGINT NOT NULL,
     height BIGINT NOT NULL,
     create_date TIMESTAMP NOT NULL

--- a/storage/src/main/kotlin/io/alienhead/gray/matter/storage/Storage.kt
+++ b/storage/src/main/kotlin/io/alienhead/gray/matter/storage/Storage.kt
@@ -7,7 +7,7 @@ interface Storage {
     fun getBlock(hash: String): StoreBlock?
     fun latestBlock(): StoreBlock?
     fun chainSize(): Long
-    fun blocks(page: Int, size: Int): List<StoreBlock>
+    fun blocks(page: Int, size: Int, sort: String?): List<StoreBlock>
 }
 
 data class StoreBlock(


### PR DESCRIPTION
Changes
* Added `sort` as new API parameter. Must be `ASC` or `DESC`. If excluded, default to `ASC`. Example: `/blockchain?page=2&sort=DESC`.
* Increased block data size.
* Fixed hash disappearing from REST API.
* Fixed broken tests.