### PR TITLE
Gradle improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ or run it directly from the terminal:
 * Run `./gradlew check` to run all checks, including tests.
 * Run `./gradlew clean` to clean all build outputs.
 
+#### Dependencies
+Dependency versions are centralized in `gradle.properties`. 
+New dependencies should be added to this list in alphabetical order.
+
+Gray-matter requires an installation of Java 21. The Temurin SDK is recommended.
+
 ### Running locally
 Three nodes are configured to run locally if you use IntelliJ. 
 The run configurations should be automatically added to your IDE.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,11 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    val kotlinxSerialization: String by project
+    val postgresql: String by project
+    val logback: String by project
+
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerialization")
 
     implementation("io.ktor:ktor-server-core")
     implementation("io.ktor:ktor-server-netty")
@@ -16,9 +20,9 @@ dependencies {
     implementation("io.ktor:ktor-client-cio")
     implementation("io.ktor:ktor-client-content-negotiation")
 
-    implementation("org.postgresql:postgresql:42.7.5")
+    implementation("org.postgresql:postgresql:$postgresql")
 
-    implementation("ch.qos.logback:logback-classic:1.5.16")
+    implementation("ch.qos.logback:logback-classic:$logback")
 
     implementation(project(":network"))
     implementation(project(":blockchain"))
@@ -27,5 +31,5 @@ dependencies {
 }
 
 application {
-    mainClass.set("com.example.AppKt")
+    mainClass.set("io.alienhead.gray.matter.app.AppKt")
 }

--- a/blockchain/build.gradle.kts
+++ b/blockchain/build.gradle.kts
@@ -4,14 +4,19 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    val kotlinxSerialization: String by project
+    val kotest: String by project
+    val logback: String by project
+    val mockk: String by project
 
-    implementation("ch.qos.logback:logback-classic:1.5.16")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerialization")
+
+    implementation("ch.qos.logback:logback-classic:$logback")
 
     implementation(project(":crypto"))
     implementation(project(":storage"))
 
-    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
-    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
-    testImplementation("io.mockk:mockk:1.13.16")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotest")
+    testImplementation("io.kotest:kotest-assertions-core:$kotest")
+    testImplementation("io.mockk:mockk:$mockk")
 }

--- a/blockchain/src/main/kotlin/io/alienhead/gray/matter/blockchain/Blockchain.kt
+++ b/blockchain/src/main/kotlin/io/alienhead/gray/matter/blockchain/Blockchain.kt
@@ -82,13 +82,13 @@ data class Blockchain(
 }
 
 @Serializable
-data class Block @OptIn(ExperimentalSerializationApi::class) constructor(
+data class Block(
     val previousHash: String,
     // Data represents articles that have been minted into a json string
     val data: String,
     val timestamp: Long,
     val height: UInt,
-    @EncodeDefault val hash: String = hash(previousHash + timestamp + data),
+    @OptIn(ExperimentalSerializationApi::class) @EncodeDefault val hash: String = hash(previousHash + timestamp + data),
 ) {
     companion object {
         fun genesis(): Block {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,6 @@
 plugins {
-    kotlin("jvm") version "2.1.10" apply false
-    kotlin("plugin.serialization") version "2.1.10" apply false
-    id("io.ktor.plugin") version "3.1.0" apply false
+    kotlin("jvm") apply false
 }
-
 
 allprojects {
     repositories {

--- a/crypto/build.gradle.kts
+++ b/crypto/build.gradle.kts
@@ -4,11 +4,16 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    val kotlinxSerialization: String by project
+    val kotest: String by project
+    val logback: String by project
+    val mockk: String by project
 
-    implementation("ch.qos.logback:logback-classic:1.5.16")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerialization")
 
-    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
-    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
-    testImplementation("io.mockk:mockk:1.13.16")
+    implementation("ch.qos.logback:logback-classic:$logback")
+
+    testImplementation("io.kotest:kotest-runner-junit5:$kotest")
+    testImplementation("io.kotest:kotest-assertions-core:$kotest")
+    testImplementation("io.mockk:mockk:$mockk")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,15 @@ org.gradle.caching=true
 # (Note that some plugins may not yet be compatible with the configuration cache.)
 # https://docs.gradle.org/current/userguide/configuration_cache.html
 org.gradle.configuration-cache=true
+
+# Dependencies
+exposed=0.59.0
+flyway=11.3.3
+hikari=6.2.1
+kotlin=2.1.10
+kotest=5.9.1
+kotlinxSerialization=1.8.0
+ktor=3.1.0
+logback=1.5.16
+mockk=1.13.16
+postgresql=42.7.5

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -4,19 +4,25 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    val kotlinxSerialization: String by project
+    val kotest: String by project
+    val ktor: String by project
+    val logback: String by project
+    val mockk: String by project
 
-    implementation("io.ktor:ktor-client-core:3.1.0")
-    implementation("io.ktor:ktor-client-cio:3.1.0")
-    implementation("io.ktor:ktor-client-content-negotiation:3.1.0")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.1.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerialization")
 
-    implementation("ch.qos.logback:logback-classic:1.5.16")
+    implementation("io.ktor:ktor-client-core:$ktor")
+    implementation("io.ktor:ktor-client-cio:$ktor")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktor")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor")
+
+    implementation("ch.qos.logback:logback-classic:$logback")
 
     implementation(project(":blockchain"))
 
-    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
-    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
-    testImplementation("io.mockk:mockk:1.13.16")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotest")
+    testImplementation("io.kotest:kotest-assertions-core:$kotest")
+    testImplementation("io.mockk:mockk:$mockk")
 
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,3 +6,14 @@ include(":crypto")
 include(":network")
 include(":storage")
 include(":sql")
+
+pluginManagement {
+    val kotlin: String by settings
+    val ktor: String by settings
+
+    plugins {
+        kotlin("jvm") version kotlin apply false
+        kotlin("plugin.serialization") version kotlin apply false
+        id("io.ktor.plugin") version ktor apply false
+    }
+}

--- a/sql/build.gradle.kts
+++ b/sql/build.gradle.kts
@@ -4,20 +4,25 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    val exposed: String by project
+    val flyway: String by project
+    val hikari: String by project
+    val kotest: String by project
+    val logback: String by project
+    val mockk: String by project
 
-    implementation("org.jetbrains.exposed:exposed-core:0.59.0")
-    implementation("org.jetbrains.exposed:exposed-jdbc:0.59.0")
-    implementation("org.jetbrains.exposed:exposed-java-time:0.59.0")
-    implementation("com.zaxxer:HikariCP:6.2.1")
-    implementation("org.flywaydb:flyway-core:11.3.3")
-    implementation("org.flywaydb:flyway-database-postgresql:11.3.3")
+    implementation("org.jetbrains.exposed:exposed-core:$exposed")
+    implementation("org.jetbrains.exposed:exposed-jdbc:$exposed")
+    implementation("org.jetbrains.exposed:exposed-java-time:$exposed")
+    implementation("com.zaxxer:HikariCP:$hikari")
+    implementation("org.flywaydb:flyway-core:$flyway")
+    implementation("org.flywaydb:flyway-database-postgresql:$flyway")
 
-    implementation("ch.qos.logback:logback-classic:1.5.16")
+    implementation("ch.qos.logback:logback-classic:$logback")
 
     implementation(project(":storage"))
 
-    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
-    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
-    testImplementation("io.mockk:mockk:1.13.16")
+    testImplementation("io.kotest:kotest-runner-junit5:$kotest")
+    testImplementation("io.kotest:kotest-assertions-core:$kotest")
+    testImplementation("io.mockk:mockk:$mockk")
 }

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -4,11 +4,16 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
+    val kotlinxSerialization: String by project
+    val kotest: String by project
+    val logback: String by project
+    val mockk: String by project
 
-    implementation("ch.qos.logback:logback-classic:1.5.16")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerialization")
 
-    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
-    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
-    testImplementation("io.mockk:mockk:1.13.16")
+    implementation("ch.qos.logback:logback-classic:$logback")
+
+    testImplementation("io.kotest:kotest-runner-junit5:$kotest")
+    testImplementation("io.kotest:kotest-assertions-core:$kotest")
+    testImplementation("io.mockk:mockk:$mockk")
 }


### PR DESCRIPTION
Changes
* Moved gradle dependency versions into `gradle.properties`. They are now centralized and can be easily updated in the future.
* Moved experimentation annotation to prevent warning during `./gradlew build`.
* Fixed main class name